### PR TITLE
Fix linking in projects page

### DIFF
--- a/committees/projects/index.md
+++ b/committees/projects/index.md
@@ -6,8 +6,8 @@ The essence of Projects Committee is simple: some people want to work on things,
 and others want to do things, we make it happen.
 
 Got a project? Want to work on a project? Questions?  
-Contact projects at projects@sse.se.rit.edu
+Contact projects at <projects@sse.se.rit.edu>
   
-To see a list of on going projects, you can check out our github org https://github.com/rit-sse
+To see a list of on going projects, you can check out our [github org](https://github.com/rit-sse)
 
 ##### Projects are a great way to earn SSE membership!


### PR DESCRIPTION
On the project page, the github link and email for projects don't actually link to anything. To bring it in line with how other pages look (example: emails on the officers page), it would make sense to make the github url a link and the project email also a link.
